### PR TITLE
Host file reading

### DIFF
--- a/hosts_file_test.go
+++ b/hosts_file_test.go
@@ -1,6 +1,7 @@
 package dnsp_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gophergala/dnsp"
@@ -36,5 +37,26 @@ func TestParseHostLine(t *testing.T) {
 		if result.Host != test.host {
 			t.Errorf("For test of line %q, Host was %q, expected it to be %q", test.line, result.Host, test.host)
 		}
+	}
+}
+
+func TestHostsReaderReadAll(t *testing.T) {
+	t.Parallel()
+
+	hostsFile := strings.NewReader(`127.0.0.1 ---.chine-li.info
+127.0.0.1 -ads.avast.dwnldfr.com
+# Comment
+127.0.0.1 -reports.com-57o.net
+127.0.0.1 0-29.com`)
+
+	reader := dnsp.NewHostsReader(hostsFile)
+	result := reader.ReadAll()
+
+	if len(result) != 4 {
+		t.Errorf("Result is not of expected length 4")
+	}
+
+	if result[0].IP != "127.0.0.1" || result[0].Host != "---.chine-li.info" {
+		t.Errorf("First entry is wrong")
 	}
 }


### PR DESCRIPTION
Below is the test app I made. The sleeps allow for seeing memory usage before and after reading the file.

``` go
package main

import (
    "fmt"
    "time"

    "github.com/gophergala/dnsp"
)

func main() {
    list := make([]string, 0, 1000)

    time.Sleep(30 * time.Second)

    fmt.Println("Reading file...")
    start := time.Now()
    dnsp.ReadHostFile("/Users/leavengood/Downloads/hosts/hosts.txt", func(h *dnsp.HostEntry) {
        list = append(list, h.Host)
    })
    fmt.Printf("Reading took %v\n", time.Since(start))

    fmt.Println(len(list))

    time.Sleep(1 * time.Minute)
}
```
