### PR TITLE
Hash hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 > `dnsp` is a lightweight but powerful DNS server. Queries are blocked or
 > resolved based on a blacklist or a whitelist. Wildcard host patterns are
 > supported (e.g. `*.com`) as well as hosted, community-managed hosts files.
-> Ideal for running on mobile devices or embedded systems.
+> Ideal for running on mobile devices or embedded systems, given its [low
+> memory footprint][1].
 
 
 ### Installation
@@ -137,5 +138,6 @@ Why, you ask, is a DNS proxy useful?
 ![dnsp](https://cloud.githubusercontent.com/assets/196617/5892473/cc29afe2-a4bf-11e4-9c6a-d1cc5169d62a.png)
 
 
+[1]: https://github.com/gophergala/dnsp/pull/15#issue-55432972
 [hosts-file.net]: http://hosts-file.net
 [AdBlock]: https://getadblock.com


### PR DESCRIPTION
Instead of keeping a map of hosts, we can hash them and keep the hash sums to save space. Hashes are arrays, which means a fixed size, which is easier to manage and behaves more predictably wrt memory consumption.

After some profiling with the hosts file from http://hosts-file.net/download/hosts.txt, I noticed the following:

| Memory     | `string` [Mb] | `[8]byte` [Mb] | improvement |
|:-----------|--------------:|---------------:|------------:|
| Alloc      |        107.87 |          60.56 |      43.86% |
| TotalAlloc |        215.78 |         209.75 |       2.79% |
| Sys        |        131.24 |          67.86 |      48.29% |

The runtime for parsing the entire host file did not change noticeably (it stayed around 3.4 seconds).

So far the only downside of this approach seems to be that there is no way to list blocked hosts in the web UI. Because of that, we can only use this approach for the public hosts files (which are the huge ones anyway, private hosts files will likely be much smaller).

Closes #9, for now (we could still investigate that later).